### PR TITLE
Recommended documents

### DIFF
--- a/recommended_documents.json
+++ b/recommended_documents.json
@@ -2,9 +2,8 @@
   "bibles":  {
     "en": ["NASB", "KJV", "engNET2016eb"],
     "fi": ["FinRK", "FinSTLK2017"],
-    "es": ["spaRV1909eb"],
-    "de": ["deu1912eb"],
-    "es": ["NBLA", "LBLA"]
+    "es": ["spaRV1909eb", "NBLA", "LBLA"],
+    "de": ["deu1912eb"]
   },
   "commentaries": {
     "en": ["Gill", "MHC", "TSKe"]

--- a/recommended_documents.json
+++ b/recommended_documents.json
@@ -1,6 +1,6 @@
 {
   "bibles":  {
-    "en": ["NASB", "KJV", "engNET2016eb"],
+    "en": ["NASB", "engKJV2006eb", "engNET2016eb"],
     "fi": ["FinRK", "FinSTLK2017"],
     "es": ["spaRV1909eb", "NBLA", "LBLA"],
     "de": ["deu1912eb"]


### PR DESCRIPTION
Fix a few issues with recommended documents
1. Spanish RV1909 not showing as recommended (cause of duplicate "es" lines)
2. KJV not showing as recommended (wrong OSIS ID)